### PR TITLE
support for Mac MPS, plus Linux and Windows CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ pip install -r requirements.txt
 * CUDA version: release 11.8 (V11.8.89)
 * PyTorch version: 2.1.0+cu118
 
+For development purposes, training was tested to run on both CUDA and CPU on both Linux and Windows platforms, as well as using the latest experimental version of pyTorch with Metal Performance Shaders on Mac OS X (see below).
+
+By default the code will select hardware acceleration for your device, if available.
+
+### Experimental Mac OS Metal Performance Shaders (MPS)
+
+To enable the MPS backend, make sure you are running the latest Apple Silicon compatible hardware and follow [these instructions](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/) to get the latest Nightly build of pyTorch instead.
+
+_NOTE_: MPS has max supported precision of FP32.
+
 ## Layout
 
 The source code expects the following directory structure (currently in your home directory).

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pip install -r requirements.txt
 
 ## Layout
 
-The source code expects the following directory structure.
+The source code expects the following directory structure (currently in your home directory).
 
 ```
   └── data

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,25 @@ import argparse
 from inference import *
 from train import *
 
+DEVICE = None
+# auto-detect default device
+if sys.platform == 'darwin':
+    # Code to run on macOS
+    torch.backends.mps.enabled = True
+    DEVICE = "mps"
+    print ("MPS enabled")
+elif torch.cuda.is_available():
+    # Windows or Linux GPU acceleration
+    torch.backends.cudnn.enabled = True
+    torch.backends.cudnn.benchmark = True
+    DEVICE = "cuda"
+    print ("CUDA enabled")
+else:
+    # CPU
+    torch.backends.cudnn.enabled = False
+    DEVICE = "cpu"
+    print ("CPU enabled")
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Scene Landmark Detection',
@@ -32,7 +51,7 @@ if __name__ == '__main__':
         '--output_downsample', type=int, default=4,
         help='Down sampling factor for output resolution')
     parser.add_argument(
-        '--gpu_device', type=str, default='cuda:0',
+        '--gpu_device', type=str, default=DEVICE,
         help='GPU device')
     parser.add_argument(
         '--pretrained_model', type=str, action='append', default=[],

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from train import *
 
 DEVICE = None
 # auto-detect default device
-if sys.platform == 'darwin':
+if torch.backends.mps.is_available():
     # Code to run on macOS
     torch.backends.mps.enabled = True
     DEVICE = "mps"

--- a/src/run_inference.py
+++ b/src/run_inference.py
@@ -1,16 +1,19 @@
 import os
 import statistics as st
+import sys
+import torch
 
 if __name__ == '__main__':
 
+    home_dir = os.path.expanduser("~")
     # specify dataset path, location of checkpoints and the experiment name.
-    checkpoint_dir = '../../data/checkpoints'
-    dataset_dir = '../../data/indoor6'
+    checkpoint_dir = os.path.join(home_dir, 'data/checkpoints')
+    dataset_dir = os.path.join(home_dir, 'data/indoor6')
     experiment = '1000-125_v10'
 
     # run inference for all six scenes of the indoor6 dataset
     for scene_name in ['scene1', 'scene2a', 'scene3', 'scene4a', 'scene5', 'scene6']:
-        command = 'python .\local_inference.py --experiment_file %s_%s.txt --dataset_dir %s --checkpoint_dir %s' % (scene_name, experiment, dataset_dir, checkpoint_dir)
+        command = 'python ./local_inference.py --experiment_file %s_%s.txt --dataset_dir %s --checkpoint_dir %s' % (scene_name, experiment, dataset_dir, checkpoint_dir)
         os.system(command)
 
     # calculate metrics
@@ -19,7 +22,7 @@ if __name__ == '__main__':
     for scene_name in ['scene1', 'scene2a', 'scene3', 'scene4a', 'scene5', 'scene6']:
         subfolder = '%s_%s' % (scene_name, experiment)
         mfn = os.path.join(checkpoint_dir, subfolder, "metrics.txt")
-        mfd = open(mfn, 'r')      
+        mfd = open(mfn, 'r')
         idx = 0
         for line in mfd.readlines():
             if (idx % 2 == 0):

--- a/src/run_training.py
+++ b/src/run_training.py
@@ -5,9 +5,11 @@ from tabnanny import check
 
 if __name__ == '__main__':
 
+    home_dir = os.path.expanduser("~")
+
     # Specify the paths to the dataset and the output folders.
-    dataset_dir = '../../data/indoor6'
-    output_dir = '../../data/outputs'
+    dataset_dir = os.path.join(home_dir, "data/indoor6")
+    output_dir = os.path.join(home_dir, "data/outputs")
 
     # Specify a version number which can be incremented when training multiple variants on 
     # the same scene.
@@ -65,7 +67,7 @@ if __name__ == '__main__':
         os.makedirs(model_dir, exist_ok=True)
 
         # Create the command line string for the training job.
-        cmd = 'python .\local_training.py'
+        cmd = 'python ./local_training.py'
         cmd += ' --dataset_dir %s' % dataset_dir
         cmd += ' --scene_id %s' % scene_name
         cmd += ' --experiment_file %s.txt' % experiment_name

--- a/src/train.py
+++ b/src/train.py
@@ -233,14 +233,24 @@ def train_patches(opt):
         # Training
         training_loss = 0
         for idx, batch in enumerate(tqdm(train_dataloader)):
-            
+
             cnn.train()
 
             B1, B2, _, H, W = batch['patches'].shape
             B = B1 * B2
-            patches = batch['patches'].reshape(B, 3, H, W).to(device=device)
-            visibility = batch['visibility'].reshape(B, num_landmarks).to(device=device)
-            landmark2d = batch['landmark2d'].reshape(B, 2, num_landmarks).to(device=device)
+            patches = batch['patches']
+            visibility = batch['visibility']
+            landmark2d = batch['landmark2d']
+
+            # highest supported precision for MPS is FP32
+            if device.lower() == 'mps':
+                patches = patches.float()
+                visibility = visibility.float()
+                landmark2d = landmark2d.float()
+
+            patches = patches.reshape(B, 3, H, W).to(device=device)
+            visibility = visibility.reshape(B, num_landmarks).to(device=device)
+            landmark2d = landmark2d.reshape(B, 2, num_landmarks).to(device=device)
 
             # Batch randomization
 


### PR DESCRIPTION
As the title says, this PR add support for the new Mac Metal Performance Shaders as an alternative to CUDA for hardware acceleration, as well as the ability to run on both Linux and Windows on CPU when GPU is not available (mostly for benchmarking and development purposes). Appropriate hardware acceleration is auto-picked when available.